### PR TITLE
fix: integration with js-libp2p

### DIFF
--- a/src/heartbeat.js
+++ b/src/heartbeat.js
@@ -123,7 +123,7 @@ class Heartbeat {
 
     // expire fanout for topics we haven't published to in a while
     const now = this.gossipsub._now()
-    this.gossipsub.lastpub.forEach((topic, lastpb) => {
+    this.gossipsub.lastpub.forEach((lastpb, topic) => {
       if ((lastpb + constants.GossipSubFanoutTTL) < now) {
         this.gossipsub.fanout.delete(topic)
         this.gossipsub.lastpub.delete(topic)
@@ -131,7 +131,7 @@ class Heartbeat {
     })
 
     // maintain our fanout for topics we are publishing but we have not joined
-    this.gossipsub.fanout.forEach((topic, peers) => {
+    this.gossipsub.fanout.forEach((peers, topic) => {
       // checks whether our peers are still in the topic
       peers.forEach((peer) => {
         if (this.gossipsub.topics.has(peer)) {

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -300,6 +300,8 @@ class BasicPubSub extends Pubsub {
     asyncMap(messages, buildMessage, (err, msgObjects) => {
       if (err) callback(err)
       this._publish(utils.normalizeOutRpcMessages(msgObjects))
+
+      callback()
     })
   }
 


### PR DESCRIPTION
In the context of integrating `gossipsub` into `js-libp2p` [libp2p/js-libp2p#365](https://github.com/libp2p/js-libp2p/pull/365), some problems appeared and this PR addresses them.