### PR TITLE
Reset to v0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libp2p-gossipsub",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "A javascript implementation of gossipsub",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
The release tooling, using `aegir release` automatically bumps the version.
If we reset to v0.0.0, aegir can bump us to v0.0.1