### PR TITLE
fix: send subscriptions once ready

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -327,9 +327,19 @@ class BasicPubSub extends Pubsub {
     })
 
     // Broadcast SUBSCRIBE to all peers
-    this.peers.forEach((peer) => {
-      peer.sendSubscriptions(newTopics)
-    })
+    this.peers.forEach((peer) => sendSubscriptionsOnceReady(peer))
+    // make sure that Gossipsub is already mounted
+    function sendSubscriptionsOnceReady (peer) {
+      if (peer && peer.isWritable) {
+        return peer.sendSubscriptions(topics)
+      }
+      const onConnection = () => {
+        peer.removeListener('connection', onConnection)
+        sendSubscriptionsOnceReady(peer)
+      }
+      peer.on('connection', onConnection)
+      peer.once('close', () => peer.removeListener('connection', onConnection))
+    }
 
     this.join(newTopics)
   }

--- a/test/2-nodes.js
+++ b/test/2-nodes.js
@@ -106,7 +106,6 @@ describe('2 nodes', () => {
         startNode(nodeB.gs)
       ])
       await dialNode(nodeA, nodeB.peerInfo)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
     })
 
     afterEach(async function () {
@@ -170,7 +169,6 @@ describe('2 nodes', () => {
         startNode(nodeB.gs)
       ])
       await dialNode(nodeA, nodeB.peerInfo)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
 
       nodeA.gs.subscribe(topic)
       nodeB.gs.subscribe(topic)
@@ -289,7 +287,6 @@ describe('2 nodes', () => {
         startNode(nodeB.gs)
       ])
       await dialNode(nodeA, nodeB.peerInfo)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
 
       nodeA.gs.subscribe(topic)
       nodeB.gs.subscribe(topic)
@@ -427,7 +424,6 @@ describe('2 nodes', () => {
       ])
 
       await dialNode(nodeA, nodeB.peerInfo)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
     })
 
     after(async function () {


### PR DESCRIPTION
When we send a subscribe or unsubscribe message, we needed to wait for a while in order to guarantee that peers are properly connected. 

This way, we had no precise metrics of when to "believe" that the dial was finished and the peer properly handled by the pubsub protocol. 

In this PR, I added a function to guarantee that when we want to send SUBSCRIBE or UNSUBSCRIBE messages, we wait for peers which are still establishing a stream communication with the peer. I had problems with this when integrating `gossipsub` with `js-ipfs`, as we connect to all the bootstrap peers, and if we start using the pubsub api, we will not be able to write to peers, which are still being connected.