### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "it-length-prefixed": "^2.0.0",
     "it-pipe": "^1.0.1",
     "libp2p-floodsub": "^0.19.0",
-    "libp2p-pubsub": "~0.3.1",
+    "libp2p-pubsub": "~0.4.0",
     "p-map": "^3.0.0",
     "peer-id": "~0.13.3",
     "peer-info": "~0.17.0",


### PR DESCRIPTION
BREAKING CHANGE: getPeersSubscribed from parent class renamed to getSubscribers to remove redundant wording

We decided to rename the mention function as the previous name was redundant