### PR TITLE
fix: fix heartbeat startup/shutdown timing bug

### DIFF
--- a/src/heartbeat.js
+++ b/src/heartbeat.js
@@ -19,25 +19,24 @@ class Heartbeat {
       throw errcode(new Error(errMsg), 'ERR_HEARTBEAT_ALREADY_RUNNING')
     }
 
-    const heartbeatTimer = {
-      _onCancel: null,
-      _timeoutId: null,
-      runPeriodically: (fn, period) => {
-        heartbeatTimer._timeoutId = setInterval(fn, period)
-      },
-      cancel: () => {
-        clearTimeout(heartbeatTimer._timeoutId)
-      }
-    }
-
     const heartbeat = this._heartbeat.bind(this)
 
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       heartbeat()
-      heartbeatTimer.runPeriodically(heartbeat, constants.GossipSubHeartbeatInterval)
+      this._heartbeatTimer.runPeriodically(heartbeat, constants.GossipSubHeartbeatInterval)
     }, constants.GossipSubHeartbeatInitialDelay)
 
-    this._heartbeatTimer = heartbeatTimer
+    this._heartbeatTimer = {
+      _onCancel: null,
+      _intervalId: null,
+      runPeriodically: (fn, period) => {
+        this._heartbeatTimer._intervalId = setInterval(fn, period)
+      },
+      cancel: () => {
+        clearTimeout(timeout)
+        clearInterval(this._heartbeatTimer._intervalId)
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
The heartbeat code sets a timeout to start the heartbeat then sets an interval to perform the heartbeat.

If the node is shut down after the timeout is set but before it fires, the interval is set and the process never ends.

This PR refactors the heatbeat shutdown to clear the timeout as well as the interval.