### PR TITLE
fix: fix double publish bug

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -201,6 +201,10 @@ class BasicPubSub extends Pubsub {
    * @param {rpc.RPC.Message} msg
    */
   _processRpcMessage (msg) {
+    if (this.peerInfo.id.toB58String() === msg.from && !this._options.emitSelf) {
+      return
+    }
+
     // Emit to self
     this._emitMessage(msg.topicIDs, msg)
   }


### PR DESCRIPTION
The tests of this module are currently failing but they don't fail the build because the error that should fail it is thrown [out of the flow control](https://github.com/ChainSafe/gossipsub-js/blob/master/test/floodsub.spec.js#L21) of the tests.  An [UnhandledPromiseRejectionWarning](https://travis-ci.com/ChainSafe/gossipsub-js/jobs/278427804#L270) is thrown.

This PR:

1. Passes an `error` object to `done` if the error condition is hit
2. Fixes a bug where a message was being sent back to the sender and then emitted by the sender even though `emitSelf` was false
3. Where multiple messages are published in a test, make each message different so we can assert that they were all actually sent/received