### PR TITLE
fix: remove use of assert module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assert = require('assert')
 const { utils } = require('libp2p-pubsub')
 
 const PeerInfo = require('peer-info')
@@ -26,7 +25,9 @@ class GossipSub extends BasicPubsub {
    * @constructor
    */
   constructor (peerInfo, registrar, options = {}) {
-    assert(PeerInfo.isPeerInfo(peerInfo), 'peer info must be an instance of `peer-info`')
+    if (!PeerInfo.isPeerInfo(peerInfo)) {
+      throw new Error('peer info must be an instance of `peer-info`')
+    }
 
     super({
       debugName: 'libp2p:gossipsub',
@@ -325,7 +326,9 @@ class GossipSub extends BasicPubsub {
    * @returns {void}
    */
   join (topics) {
-    assert(this.started, 'GossipSub has not started')
+    if (!this.started) {
+      throw new Error('GossipSub has not started')
+    }
     topics = utils.ensureArray(topics)
 
     this.log('JOIN %s', topics)

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assert = require('assert')
 const errcode = require('err-code')
 
 const TimeCache = require('time-cache')
@@ -261,7 +260,9 @@ class BasicPubSub extends Pubsub {
    * @returns {void}
    */
   subscribe (topics) {
-    assert(this.started, 'Pubsub has not started')
+    if (!this.started) {
+      throw new Error('Pubsub has not started')
+    }
 
     topics = utils.ensureArray(topics)
 
@@ -305,7 +306,9 @@ class BasicPubSub extends Pubsub {
    * @returns {void}
    */
   unsubscribe (topics) {
-    assert(this.started, 'Pubsub has not started')
+    if (!this.started) {
+      throw new Error('Pubsub has not started')
+    }
 
     topics = utils.ensureArray(topics)
 
@@ -350,7 +353,9 @@ class BasicPubSub extends Pubsub {
    * @returns {void}
    */
   async publish (topics, messages) {
-    assert(this.started, 'Pubsub has not started')
+    if (!this.started) {
+      throw new Error('Pubsub has not started')
+    }
 
     this.log('publish', topics, messages)
 
@@ -387,7 +392,9 @@ class BasicPubSub extends Pubsub {
    * @returns {Array<String>}
    */
   getTopics () {
-    assert(this.started, 'Pubsub is not started')
+    if (!this.started) {
+      throw new Error('Pubsub is not started')
+    }
 
     return Array.from(this.subscriptions)
   }


### PR DESCRIPTION
I'm trying to remove use of the node `assert` module from our stack as it's causing problems - the polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.