### PR TITLE
add typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "src",
     "dist"
   ],
+  "types": "src/index.d.ts",
   "scripts": {
     "lint": "aegir lint",
     "release": "aegir release",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for libp2p-gossipsub v0.2.3
+// Project https://github.com/ChainSafe/gossipsub-js
+
+/// <reference types="node"/>
+
+import PeerInfo = require('peer-info');
+
+export interface Registrar {
+    handle: Function;
+    register(topology: Object): string;
+    unregister(id: string): boolean;
+}
+
+export interface IGossipMessage {
+    from: Buffer | string;
+    data: Buffer;
+    seqno: Buffer;
+    topicIDs: string[];
+}
+
+export interface Options {
+    emitSelf?: boolean,
+    gossipIncoming?: boolean,
+    fallbackToFloodsub?: boolean,
+}
+
+import * as Events from "events";
+
+interface GossipSub extends Events.EventEmitter {}
+
+declare class GossipSub  {
+    constructor(peerInfo: PeerInfo, registrar: Registrar, options: Options);
+    publish(topic: string, data: Buffer): Promise<void>;
+    start(): Promise<void>;
+    stop(): Promise<void>;
+    subscribe(topic: string): void;
+    unsubscribe(topic: string): void;
+    validate(message: IGossipMessage): Promise<boolean>;
+    _emitMessage(topics: string[], message: IGossipMessage): void;
+    getTopics(): string[];
+    _publish(messages: IGossipMessage[]): void;
+}
+
+export default GossipSub;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "target": "ES5",
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "baseUrl": ".",
+    },
+    "types": [
+      "node",
+      "mocha",
+      "chai"
+    ],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "./src/index.d.ts"
+  ]
+}


### PR DESCRIPTION
resolves #50 

Types are migrated from https://github.com/ChainSafe/libp2p-ts *

* removed `message-id` as it's not specified in spec or in proto file