### PR TITLE
Provide a way to override message id function

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,7 @@ Options is an optional object with the following key-value pairs:
 
 * **`fallbackToFloodsub`**: boolean identifying whether the node should fallback to the floodsub protocol, if another connecting peer does not support gossipsub (defaults to **true**).
 * **`emitSelf`**: boolean identifying whether the node should emit to self on publish, in the event of the topic being subscribed (defaults to **false**).
-* **`msgIdFn`**: a function defining the message id given a message, this is optional. For example:
-```js
-const msgIdFn = (message) => Buffer.from(hash(message.data)).toString("base64")
-```
+* **`msgIdFn`**: a function with signature `(message) => string` defining the message id given a message, used internally to deduplicate gossip (defaults to `(message) => message.from + message.seqno.toString('hex')`)
 
 For the remaining API, see https://github.com/libp2p/js-libp2p-pubsub
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Options is an optional object with the following key-value pairs:
 * **`fallbackToFloodsub`**: boolean identifying whether the node should fallback to the floodsub protocol, if another connecting peer does not support gossipsub (defaults to **true**).
 * **`emitSelf`**: boolean identifying whether the node should emit to self on publish, in the event of the topic being subscribed (defaults to **false**).
 * **`msgIdFn`**: a function with signature `(message) => string` defining the message id given a message, used internally to deduplicate gossip (defaults to `(message) => message.from + message.seqno.toString('hex')`)
+* **`messageCache`**: optional, a customized `MessageCache` instance, see the implementation for the interface.
 
 For the remaining API, see https://github.com/libp2p/js-libp2p-pubsub
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Options is an optional object with the following key-value pairs:
 
 * **`fallbackToFloodsub`**: boolean identifying whether the node should fallback to the floodsub protocol, if another connecting peer does not support gossipsub (defaults to **true**).
 * **`emitSelf`**: boolean identifying whether the node should emit to self on publish, in the event of the topic being subscribed (defaults to **false**).
+* **`msgIdFn`**: a function defining the message id given a message, this is optional. For example:
+```js
+const msgIdFn = (message) => Buffer.from(hash(message.data)).toString("base64")
+```
 
 For the remaining API, see https://github.com/libp2p/js-libp2p-pubsub
 

--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,13 @@ class GossipSub extends BasicPubsub {
     })
   }
 
+  /**
+   * Override the default implementation in BasicPubSub.
+   * If we don't provide msgIdFn in constructor option, it's the same.
+   * @override
+   * @param {rpc.RPC.Message} msg the message object
+   * @returns {string} message id as string
+   */
   getMsgId (msg) {
     return this._msgIdFn(msg)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ class GossipSub extends BasicPubsub {
    * @param {bool} [options.emitSelf] if publish should emit to self, if subscribed, defaults to false
    * @param {bool} [options.gossipIncoming] if incoming messages on a subscribed topic should be automatically gossiped, defaults to true
    * @param {bool} [options.fallbackToFloodsub] if dial should fallback to floodsub, defaults to true
+   * @param {function} [options.msgIdFn] override the default message id function
    * @constructor
    */
   constructor (peerInfo, registrar, options = {}) {
@@ -73,10 +74,15 @@ class GossipSub extends BasicPubsub {
     this.control = new Map()
 
     /**
+     * Use the overriden mesgIdFn or the default one.
+     */
+    this._msgIdFn = options.msgIdFn || this.defaultMsgIdFn
+
+    /**
      * A message cache that contains the messages for last few hearbeat ticks
      *
      */
-    this.messageCache = new MessageCache(constants.GossipSubHistoryGossip, constants.GossipSubHistoryLength)
+    this.messageCache = new MessageCache(constants.GossipSubHistoryGossip, constants.GossipSubHistoryLength, this._msgIdFn)
 
     /**
      * A heartbeat timer that maintains the mesh
@@ -372,6 +378,10 @@ class GossipSub extends BasicPubsub {
         this.mesh.delete(topic)
       }
     })
+  }
+
+  getMsgId (msg) {
+    return this._msgIdFn(msg)
   }
 
   _publish (messages) {

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class GossipSub extends BasicPubsub {
    * @param {bool} [options.gossipIncoming] if incoming messages on a subscribed topic should be automatically gossiped, defaults to true
    * @param {bool} [options.fallbackToFloodsub] if dial should fallback to floodsub, defaults to true
    * @param {function} [options.msgIdFn] override the default message id function
+   * @param {Object} [options.messageCache] override the default MessageCache
    * @constructor
    */
   constructor (peerInfo, registrar, options = {}) {
@@ -82,7 +83,7 @@ class GossipSub extends BasicPubsub {
      * A message cache that contains the messages for last few hearbeat ticks
      *
      */
-    this.messageCache = new MessageCache(constants.GossipSubHistoryGossip, constants.GossipSubHistoryLength, this._msgIdFn)
+    this.messageCache = options.messageCache || new MessageCache(constants.GossipSubHistoryGossip, constants.GossipSubHistoryLength, this._msgIdFn)
 
     /**
      * A heartbeat timer that maintains the mesh

--- a/src/messageCache.js
+++ b/src/messageCache.js
@@ -53,9 +53,18 @@ class MessageCache {
    * @returns {void}
    */
   put (msg) {
-    const msgID = this.msgIdFn(msg)
+    const msgID = this.getMsgId(msg)
     this.msgs.set(msgID, msg)
     this.history[0].push(new CacheEntry(msgID, msg.topicIDs))
+  }
+
+  /**
+   * Get message id of message.
+   * @param {rpc.RPC.Message} msg
+   * @returns {string}
+   */
+  getMsgId (msg) {
+    return this.msgIdFn(msg)
   }
 
   /**

--- a/src/messageCache.js
+++ b/src/messageCache.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { utils } = require('libp2p-pubsub')
-
 class CacheEntry {
   /**
    * @param {String} msgID
@@ -19,10 +17,11 @@ class MessageCache {
   /**
    * @param {Number} gossip
    * @param {Number} history
+   * @param {msgIdFn} msgIdFn a function that returns message id from a message
    *
    * @constructor
    */
-  constructor (gossip, history) {
+  constructor (gossip, history, msgIdFn) {
     /**
      * @type {Map<string, RPC.Message>}
      */
@@ -40,6 +39,11 @@ class MessageCache {
      * @type {Number}
      */
     this.gossip = gossip
+
+    /**
+     * @type {Function}
+     */
+    this.msgIdFn = msgIdFn
   }
 
   /**
@@ -49,7 +53,7 @@ class MessageCache {
    * @returns {void}
    */
   put (msg) {
-    const msgID = utils.msgId(msg.from, msg.seqno)
+    const msgID = this.msgIdFn(msg)
     this.msgs.set(msgID, msg)
     this.history[0].push(new CacheEntry(msgID, msg.topicIDs))
   }

--- a/test/messageCache.spec.js
+++ b/test/messageCache.spec.js
@@ -18,7 +18,7 @@ const getMsgID = (msg) => {
 }
 
 describe('Testing Message Cache Operations', () => {
-  const messageCache = new MessageCache(3, 5)
+  const messageCache = new MessageCache(3, 5, getMsgID)
   const testMessages = []
 
   before(() => {


### PR DESCRIPTION
## Goal
+ Lodestar/eth2 wants a way to specify its own `msgId()` function 
+ The change should be backward compatible

## Details
+ Have default message id function calculated as earlier
+ Provide a way to override that as opttions
+ This is inspired by https://github.com/libp2p/go-libp2p-pubsub/pull/248/files